### PR TITLE
Update dev_guide.rst: BEP 2 retired

### DIFF
--- a/sphinx/source/docs/dev_guide.rst
+++ b/sphinx/source/docs/dev_guide.rst
@@ -25,9 +25,6 @@ The software development process for Bokeh is outlined in
 `Bokeh Enhancement Proposal 1`_. All changes, enhancements,
 and bugfixes should generally go through the process outlined there.
 
-The process for creating, distributing, and announcing final releases
-of Bokeh is outlined in `Bokeh Enhancement Proposal 2`_.
-
 ------
 
 :ref:`devguide_setup`


### PR DESCRIPTION
dev_guide.rst modified due to the fact it is mentioned the BEP 2 proposal that was retired last year.

Pull request started according to what said [here](https://discourse.bokeh.org/t/documentation-enhancement-proposal-2/4942)

Related issue: [#8448](https://github.com/bokeh/bokeh/issues/8448)